### PR TITLE
return namespace assigned to --namespace

### DIFF
--- a/cmd/helm/helm.go
+++ b/cmd/helm/helm.go
@@ -129,6 +129,10 @@ func kubeConfig() genericclioptions.RESTClientGetter {
 }
 
 func getNamespace() string {
+	if settings.Namespace != "" {
+		return settings.Namespace
+	}
+	
 	if ns, _, err := kubeConfig().ToRawKubeConfigLoader().Namespace(); err == nil {
 		return ns
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
If your local kubeconfig already has a namespace set the current logic uses that namespace instead of the namepace supplied to the `--namespace` flag during install. 

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
